### PR TITLE
Add keyring/keychain cache location to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,9 @@ The Credential Provider will save session tokens in the following locations:
 -   Windows: `$env:UserProfile\AppData\Local\MicrosoftCredentialProvider`
 -   Linux/MAC: `$HOME/.local/share/MicrosoftCredentialProvider/`
 
+On Linux or Mac, the tokens are additionally saved to the Keyring/Keychain under the collection name `Microsoft.Developer.IdentityService`.
+
+
 ## Environment Variables
 
 The Credential Provider accepts a set of environment variables. Not all of them we recommend using in production, but these two are considered safe.


### PR DESCRIPTION
On Mac/Linux, the Token Cache uses the keyring/keychain functionality of the OS to save the tokens in addition to the default cache location on the file system.

This was undocumented and led to tedious debugging experiences.

This PR adds the location info for [macOS Keychain](https://github.com/microsoft/artifacts-credprovider/blob/dc5f4a2da94af69f444b5fd709e889dce23ac026/src/Authentication/MsalCache.cs#L79) and [Linux Keyring](https://github.com/microsoft/artifacts-credprovider/blob/dc5f4a2da94af69f444b5fd709e889dce23ac026/src/Authentication/MsalCache.cs#L88C1-L88C1).